### PR TITLE
Bikeshed infrastructure

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,25 @@
+---
+name: Add review url
+
+on:
+  pull_request_target:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Automated Review URLs
+
+      - uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            #### Automated Review URLs
+            * [render latest/index.bs](http://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/GraphBLAS/binsparse-specification/${{ github.event.pull_request.head.sha }}/latest/index.bs)
+          edit-mode: replace

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -21,5 +21,5 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             #### Automated Review URLs
-            * [render latest/index.bs](http://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/GraphBLAS/binsparse-specification/${{ github.event.pull_request.head.sha }}/latest/index.bs)
+            * [render latest/index.bs](http://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/GraphBLAS/binsparse-specification/${{ github.event.pull_request.head.sha }}/spec/latest/index.bs)
           edit-mode: replace

--- a/README.md
+++ b/README.md
@@ -2,3 +2,17 @@
 This is part of a new effort to create a binary storage format for storing sparse matrices and other sparse data to disk.
 
 [Minutes from our meetings](minutes) are available.
+
+## Specification
+
+The working version of the specification can be found under `spec/latest/index.bs`.
+
+### Editing
+
+The spec is written in [bikeshed](https://github.com/tabatkins/bikeshed) – a variant of markdown.
+To render the spec locally:
+
+* Install bikeshed (ideally in an isolated environment): `pipx install bikeshed`
+* Call `bikeshed spec spec/latest/index.md`
+
+Rendered versions will generated for pull requests.

--- a/spec/latest/index.bs
+++ b/spec/latest/index.bs
@@ -1,0 +1,16 @@
+<pre class='metadata'>
+Title: Your Spec Title
+Shortname: your-spec
+Level: 1
+Status: w3c/UD
+Group: WGNAMEORWHATEVER
+URL: http://example.com/url-this-spec-will-live-at
+Editor: Your Name, Your Company http://example.com/your-company, your-email@example.com, http://example.com/your-personal-website
+Abstract: A short description of your spec, one or two sentences.
+</pre>
+
+Introduction {#intro}
+=====================
+
+Introduction here.
+

--- a/spec/latest/index.bs
+++ b/spec/latest/index.bs
@@ -1,5 +1,5 @@
 <pre class='metadata'>
-Title: Your Spec Title
+Title: Binary Sparse Format Specification
 Shortname: binsparse
 Level: 1
 Status: LS-COMMIT
@@ -8,6 +8,10 @@ Group: GraphBLAS
 URL: http://example.com/url-this-spec-will-live-at
 Repository: https://github.com/GraphBLAS/binsparse-specification
 Editor: Benjamin Brock, Intel
+Editor: Tim Davis, Texas A&M
+Editor: Jim Kitchen, Anaconda
+Editor: Erik Welch, NVIDIA
+Editor: Isaac Virshup, Helmholtz Munich
 Editor: Your Name, Your Company http://example.com/your-company, your-email@example.com, http://example.com/your-personal-website
 Abstract: A cross-platform binary storage format for sparse data, particularly sparse matrices.
 </pre>

--- a/spec/latest/index.bs
+++ b/spec/latest/index.bs
@@ -1,12 +1,15 @@
 <pre class='metadata'>
 Title: Your Spec Title
-Shortname: your-spec
+Shortname: binsparse
 Level: 1
-Status: w3c/UD
-Group: WGNAMEORWHATEVER
+Status: LS-COMMIT
+Status: UD
+Group: GraphBLAS
 URL: http://example.com/url-this-spec-will-live-at
+Repository: https://github.com/GraphBLAS/binsparse-specification
+Editor: Benjamin Brock, Intel
 Editor: Your Name, Your Company http://example.com/your-company, your-email@example.com, http://example.com/your-personal-website
-Abstract: A short description of your spec, one or two sentences.
+Abstract: A cross-platform binary storage format for sparse data, particularly sparse matrices.
 </pre>
 
 Introduction {#intro}

--- a/spec/latest/index.bs
+++ b/spec/latest/index.bs
@@ -3,7 +3,7 @@ Title: Your Spec Title
 Shortname: binsparse
 Level: 1
 Status: LS-COMMIT
-Status: UD
+Status: w3c/UD
 Group: GraphBLAS
 URL: http://example.com/url-this-spec-will-live-at
 Repository: https://github.com/GraphBLAS/binsparse-specification


### PR DESCRIPTION
Starting bike shed infrastructure.

This is based on the setup of https://github.com/ome/ngff.

The github action won't run until this is merged (so it's a little hard to check if it worked). But it will run without needing maintainer approval in the future.

Things I'm intentionally leaving undone:

* Deploying the version on `main`. We'd need somewhere to deploy it to. Github pages could work, but I think this would need to be setup by an org owner.
* Filling in text – I'm thinking we can do a skeleton, then PR in text once CI is up