### PR TITLE
Updates based on feedback from spec meeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ The spec is written in [bikeshed](https://github.com/tabatkins/bikeshed) – a v
 To render the spec locally:
 
 * Install bikeshed (ideally in an isolated environment): `pipx install bikeshed`
-* Call `bikeshed spec spec/latest/index.md`
+* Call `bikeshed spec spec/latest/index.bs`
 
 Rendered versions will generated for pull requests.

--- a/spec/latest/index.bs
+++ b/spec/latest/index.bs
@@ -47,9 +47,11 @@ indices are 0-based positive integers.
 Binsparse JSON Descriptors {#descriptor}
 ========================================
 
-Binsparse descriptors are JSON blobs that describe the binary format of sparse
-data.  The JSON blob includes several required keys that describe the structure of
-the binary storage. Optional attributes may be defined to hold additional metadata.
+Binsparse descriptors are key-value metadata that describe the binary format of sparse
+data.  The key-value data is namespaced as "binsparse" to avoid any conflict with other
+metadata in the container. The required entries in the "binsparse" entry are listed
+below. Optional attributes may be defined to hold additional metadata and must be stored
+outside of the "binsparse" namespace.
 
 <div class=example>
 
@@ -58,17 +60,17 @@ and 12 columns, containing float32 values, along with user-defined attributes.
 
 ```json
 {
-  "format": "CSC",
-  "shape": [10, 12],
-  "data_types": {
-    "pointers_0": "uint64",
-    "indices_1": "uint64",
-    "values": "float32"
+  "binsparse": {
+    "format": "CSC",
+    "shape": [10, 12],
+    "data_types": {
+      "pointers_0": "uint64",
+      "indices_1": "uint64",
+      "values": "float32"
+    }
   },
-  "attrs": {
-    "original_source": "https://url/of/original/file.mtx",
-    "author": "John Doe"
-  }
+  "original_source": "https://url/of/original/file.mtx",
+  "author": "John Doe"
 }
 ```
 
@@ -223,12 +225,12 @@ Data Types {#key_data_types}
 ----------------------------
 
 The `data_types` key must be present and shall define the data types of all required
-arrays based on the [[#key_format]]. The data type declares the type of the
-in-memory arrays. While these are often identical to the types used when storing
-the arrays on disk in the container, the container may choose to store the arrays
-in another format. For example, `uint64` type may be stored as `int8` if all the
-numbers in the array are small enough to fit, but `data_types` would still list the
-array as having type `uint64`.
+arrays based on the [[#key_format]]. The data type declares the type of both the
+on-disk array as well as the in-memory array. When these are identical, a simple string
+defines the type. When the on-disk and in-memory types differ due to limitations in the
+storage container (ex. HDF5 lacks a BOOL type), the type is shown as "on_disk->in_memory".
+For the example of storing BOOL type as INT8, this would be "int8->bool" to indicate that
+after reading the values array into memory, it should be interpreted as boolean data.
 
 For a given [[#key_format]], all named binary arrays for that format shall have a
 corresponding name in `data_types`.
@@ -237,7 +239,7 @@ corresponding name in `data_types`.
 
 When all values of a sparse array are the same identical value, a special syntax is
 provided to compress the value array to a single value rather than duplicating the same
-number unnecessarily. The type is written as `1x[<type>]` to indicate that the array
+number unnecessarily. The type is written as `iso[<type>]` to indicate that the array
 will store only a single element which is common to all stored indices.
 
 <div class=example>
@@ -261,16 +263,16 @@ Example of a CSR Matrix whose values are all 1.
     <td>.</td>
     <td>.</td>
     <td>.</td>
-    <td>1</td>
+    <td>7</td>
     <td>.</td>
   </tr>
   <tr>
     <th>1</th>
     <td>.</td>
-    <td>1</td>
+    <td>7</td>
     <td>.</td>
     <td>.</td>
-    <td>1</td>
+    <td>7</td>
   </tr>
   <tr>
     <th>2</th>
@@ -283,8 +285,8 @@ Example of a CSR Matrix whose values are all 1.
   <tr>
     <th>3</th>
     <td>.</td>
-    <td>1</td>
-    <td>1</td>
+    <td>7</td>
+    <td>7</td>
     <td>.</td>
     <td>.</td>
   </tr>
@@ -293,7 +295,7 @@ Example of a CSR Matrix whose values are all 1.
     <td>.</td>
     <td>.</td>
     <td>.</td>
-    <td>1</td>
+    <td>7</td>
     <td>.</td>
   </tr>
   </tbody>
@@ -306,14 +308,14 @@ Example of a CSR Matrix whose values are all 1.
   "data_types": {
     "pointers_0": "uint64",
     "indices_1": "uint64",
-    "values": "1x[int8]"
+    "values": "iso[int8]"
   }
 }
 ```
 
 - `pointers_0` = [0, 1, 3, 3, 5, 6]
 - `indices_1` = [3, 1, 4, 1, 2, 3]
-- `values` = [1]
+- `values` = [7]
 
 </div>
 


### PR DESCRIPTION
- Change `1x[int8]` to `iso[int8]`
- Change the iso value from 1 to 7 to clarify the intended usage
- Namespace the metadata, moving required elements under "binsparse" and moving optional attributes to the top level
- Change the wording on data_types to show what is stored on disk, and the mechanism to indicate how it should be interpreted in-memory if different