### PR TITLE
Swap ISO to be represented in format instead of value type

### DIFF
--- a/spec/latest/index.bs
+++ b/spec/latest/index.bs
@@ -242,12 +242,12 @@ corresponding name in `data_types`.
 
 When all values of a sparse array are the same identical value, a special syntax is
 provided to compress the value array to a single value rather than duplicating the same
-number unnecessarily. The type is written as `iso[<type>]` to indicate that the array
-will store only a single element which is common to all stored indices.
+number unnecessarily. The format of the array is written as `iso[<format>]` to indicate
+that the array will store only a single element which is common to all stored indices.
 
 <div class=example>
 
-Example of a CSR Matrix whose values are all 1.
+Example of a CSR Matrix whose values are all 7.
 
 <table>
   <thead>
@@ -306,12 +306,12 @@ Example of a CSR Matrix whose values are all 1.
 
 ```json
 {
-  "format": "CSR",
+  "format": "iso[CSR]",
   "shape": [5, 5],
   "data_types": {
     "pointers_0": "uint64",
     "indices_1": "uint64",
-    "values": "iso[int8]"
+    "values": "int8"
   }
 }
 ```


### PR DESCRIPTION
[Based on our discussion today](https://hackmd.io/0qzK4fJlQp-78t067yiYsA?view), starting this PR to represent ISO matrices through the format rather than value.