### PR TITLE
Add versioning to format

### DIFF
--- a/spec/latest/index.bs
+++ b/spec/latest/index.bs
@@ -1,5 +1,5 @@
 <pre class='metadata'>
-Title: Binary Sparse Format Specification Version 0.5
+Title: Binary Sparse Format Specification Version 0.1
 Shortname: binsparse
 Level: 1
 Status: LS-COMMIT
@@ -61,7 +61,7 @@ and 12 columns, containing float32 values, along with user-defined attributes.
 ```json
 {
   "binsparse": {
-    "version": "0.5",
+    "version": "0.1",
     "format": "CSC",
     "shape": [10, 12],
     "data_types": {
@@ -358,7 +358,7 @@ Example of a CSR Matrix whose values are all 7.
 
 ```json
 {
-  "version": "0.5",
+  "version": "0.1",
   "format": "CSR",
   "shape": [5, 5],
   "data_types": {
@@ -495,7 +495,7 @@ Example of a symmetric CSR matrix.
 
 ```json
 {
-  "version": "0.5",
+  "version": "0.1",
   "format": "CSR",
   "shape": [5, 5],
   "structure": "symmetric_lower",

--- a/spec/latest/index.bs
+++ b/spec/latest/index.bs
@@ -61,6 +61,7 @@ and 12 columns, containing float32 values, along with user-defined attributes.
 ```json
 {
   "binsparse": {
+    "version": "1.0",
     "format": "CSC",
     "shape": [10, 12],
     "data_types": {
@@ -75,6 +76,14 @@ and 12 columns, containing float32 values, along with user-defined attributes.
 ```
 
 </div>
+
+Version {#key_version}
+----------------------
+
+Version indicates the version of the Binsparse specification used here.
+This is a two digit specifier of the form `major.minor`.
+Any minor updates should be backwards compatible with the previous version, e.g. must be a superset of the previous versions within the major release series.
+Major versions may break backwards compatibility.
 
 Shape {#key_shape}
 ------------------
@@ -349,6 +358,7 @@ Example of a CSR Matrix whose values are all 7.
 
 ```json
 {
+  "version": "1.0",
   "format": "CSR",
   "shape": [5, 5],
   "data_types": {
@@ -485,6 +495,7 @@ Example of a symmetric CSR matrix.
 
 ```json
 {
+  "version": "1.0",
   "format": "CSR",
   "shape": [5, 5],
   "structure": "symmetric_lower",

--- a/spec/latest/index.bs
+++ b/spec/latest/index.bs
@@ -1,5 +1,5 @@
 <pre class='metadata'>
-Title: Binary Sparse Format Specification
+Title: Binary Sparse Format Specification Version 0.5
 Shortname: binsparse
 Level: 1
 Status: LS-COMMIT
@@ -61,7 +61,7 @@ and 12 columns, containing float32 values, along with user-defined attributes.
 ```json
 {
   "binsparse": {
-    "version": "1.0",
+    "version": "0.5",
     "format": "CSC",
     "shape": [10, 12],
     "data_types": {
@@ -358,7 +358,7 @@ Example of a CSR Matrix whose values are all 7.
 
 ```json
 {
-  "version": "1.0",
+  "version": "0.5",
   "format": "CSR",
   "shape": [5, 5],
   "data_types": {
@@ -495,7 +495,7 @@ Example of a symmetric CSR matrix.
 
 ```json
 {
-  "version": "1.0",
+  "version": "0.5",
   "format": "CSR",
   "shape": [5, 5],
   "structure": "symmetric_lower",


### PR DESCRIPTION
This PR adds a `"version"` attribute to the format.

This proposes a two digit version specifier: `MAJOR.MINOR`, like a truncated [semver](https://semver.org) specifier.

* `MAJOR` increments mean that there are breaking changes
* `MINOR` increments indicate additions. Any minor increments must strictly be additions to the specification and must be compatible with all previous minor releases within the major release series. If a reader is capable of reading a version 1.1 store, it must be able to read a version 1.0 store.
* There is no `PATCH`, because it's unclear what a bug fix means in the context of specifications

## Possible addition: development/ release candidate versioning

I would like to be able to have release candidates/ development versions for this specification. The main thing here is to give us a way to hack on the specification before committing to a final version. That way any files we write and share during this phase are clearly marked as potentially being invalid. I would propose following semantic versioning or python's PEP440 to support release candidates and development versions ([notes on compatibility](https://peps.python.org/pep-0440/#semantic-versioning)). The PEP is suggested since I don't believe I've seen many non-python projects use the semver release candidates and dev semantics.

| | [semver](https://semver.org)  | [PEP440](https://peps.python.org/pep-0440/) |
| --- | ------------- | ------------- |
| Development | [a little unclear](https://semver.org/#spec-item-10) | X.Y.devN  |
| Release Candidate | X.Y-rcN  | X.YrcN  |

This wouldn't strictly need to be documented in the spec, but it would be good to document somewhere.

## Alternatives

### No `MINOR`

When I reached out to `OME-NGFF` I was told they only intend to have a single digit version. They are only doing versions like `0.4` right now because it is still broadly unstable.

We could do the same thing here. However, we have discussed multiple additions that would not neccesitate full nD support, but would increase the scope of the spec. This includes: chunking, triangular formats, masked formats.

### `PATCH`

The `PATCH` is not included because it's not clear what a bug fix for a file format should mean. There are specifications that use a patch release:

## Prior art

* CF conventions (NetCDF Climate and Forecast Metadata Conventions) uses a similar versioning scheme: http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/cf-conventions.html#revhistory
* Arrow specifies the library and format number separately. While they do use 3 digits, I can't find an example where the third digit is used for the format post 1.0, and versions are referred to by two digits in the [documentation](https://arrow.apache.org/docs/format/Columnar.html) and [flat buffer spec](https://github.com/apache/arrow/blob/943bf4887648bd14a7acc071497a4e4c39788bbe/format/Schema.fbs#L20-L24)
* SBOL (systems biology language) uses a three digit version, though I don't believe they are following semver (e.g. [3.0.1 seems like it added features](https://sbolstandard.org/datamodel-specification/))
* EML (Ecological metadata language) uses a three digit version where bug fixes can include typos in the specification. I don't think these need to be included in the file format, through do indicate a need for documentation that can be versioned separately from the format itself.
