### PR TITLE
Add an addition to the spec to support 1-indexed memory

### DIFF
--- a/spec/latest/index.bs
+++ b/spec/latest/index.bs
@@ -40,8 +40,7 @@ with a value as a *stored value*.  Stored values have associated with them a
 or more *indices*, which describe the location where the stored value is located
 in the array. Some or all of these indices may be stored explicitly, or they may
 be implicitly derived, depending on storage format.  When stored explicitly,
-indices are 0-based positive integers. 
-
+indices are 0-based positive integers.
 
 Binsparse JSON Descriptors {#descriptor}
 ========================================
@@ -116,6 +115,14 @@ The `fill` key may be present. If the `fill` key is present, it shall have a
 boolean value. If the value is true, it signifies the presence of a `fill_value`
 array, whose single element defines the value at indices not specified
 by the sparse tensor structure.
+
+Index Base {#key_base}
+----------------------
+
+The `index_base` key allows the programmer to specify whether the indices are
+base 0 or base 1. If not present, this key defaults to 0. When `index_base` is
+1, all `indices_*` and `pointers_to_*` should have values one greater than
+currently defined in this spec.
 
 Format {#key_format}
 --------------------
@@ -378,7 +385,13 @@ present:
 :: Array of size `number_of_positions + 1` whose 1st element is equal to `0` and whose `p + 1`th element is equal to the sum of `pointers_to_(N - n)[p]` and the number of explicitly represented slices in the `p`th position.
 
 : indices_(N - n), ..., indices(N - n + r - 1)
-:: There are `r` such arrays. When `A[i_0, ..., i_(r - 1), :, ..., :]` is explicitly represented by the subarray in position `q`, `indices_(N-n+s)[q] = i_s`. The arrays must be ordered such that the tuples `(indices_(N-n)[q], ..., indices_(N-n+r-1)[q])` are unique and appear in lexicographic order for all `q` in each range `pointers_to_(N-n)[p] <= q < pointers_to_(N-n)[p + 1]`. This array must contain no other elements.
+:: There are `r` such arrays. When `A[i_0, ..., i_(r - 1), :, ..., :]` is explicitly represented by the subarray in position `q`, `indices_(N-n+s)[q] = i_s`. The tuples `(indices_(N-n)[q], ..., indices_(N-n+r-1)[q])` must be unique for all `q` in each range `pointers_to_(N-n)[p] <= q < pointers_to_(N-n)[p + 1]`. This array must contain no other elements.
+
+If the `sorted` key is present, it's Boolean value may be used to indicate
+whether the tuples `(indices_(N-n)[q], ..., indices_(N-n+r-1)[q])` appear in
+lexicographic order for all `q` in each range `pointers_to_(N-n)[p] <= q <
+pointers_to_(N-n)[p + 1]`. If the `sorted` key is not present, the tuples are
+assumed to be sorted.
 
 Special note: If the sparse level is the root level, the `pointers` array should
 be ommitted, as its first value will be `0` and its last value will be the


### PR DESCRIPTION
In languages which index from 1, it's most convenient to be able to use a 1-indexed format, especially when checkpointing or working with in-memory transfers, where we might want to use binsparse internally. While I know that most uses of Binsparse will want a 0-indexed option, Fortran, Julia, and Matlab all index from 1 and are big sparse matrix languages.